### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ Optional speedups for GitDB
 Installation
 ============
 
-.. image:: https://pypip.in/version/gitdb-speedups/badge.svg
+.. image:: https://img.shields.io/pypi/v/gitdb-speedups.svg
     :target: https://pypi.python.org/pypi/gitdb-speedups/
     :alt: Latest Version
-.. image:: https://pypip.in/py_versions/gitdb-speedups/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/gitdb-speedups.svg
     :target: https://pypi.python.org/pypi/gitdb-speedups/
     :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20gitdb-speedups))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `gitdb-speedups`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.